### PR TITLE
Got ESP3D working

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -112,7 +112,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-// #define SERIAL_PORT_2 -1
+#define SERIAL_PORT_2 2
 
 /**
  * This setting determines the communication speed of the printer.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1591,13 +1591,13 @@
 // For debug-echo: 128 bytes for the optimal speed.
 // Other output doesn't need to be that speedy.
 // :[0, 2, 4, 8, 16, 32, 64, 128, 256]
-#define TX_BUFFER_SIZE 0
+#define TX_BUFFER_SIZE 128
 
 // Host Receive Buffer Size
 // Without XON/XOFF flow control (see SERIAL_XON_XOFF below) 32 bytes should be enough.
 // To use flow control, set this buffer size to at least 1024 bytes.
 // :[0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
-//#define RX_BUFFER_SIZE 1024
+#define RX_BUFFER_SIZE 1024
 
 #if RX_BUFFER_SIZE >= 1024
   // Enable to have the controller send XON/XOFF control characters to


### PR DESCRIPTION
This enables [ESP3D](https://github.com/luc-github/ESP3D) on the Ender2 + Ender2 LCD + BTT SKR Mini E3 combo.

ESP3D can be connected to the board through the TFT header. A pinout for the TFT header (and all other connections on the board) is available [here](https://ae01.alicdn.com/kf/H90c51a00a0b24bc5979beee3ca938c5eo.jpg).

- Swapped SERIAL_PORT and SERIAL_PORT_2 around compared to what BTT says you should do, that fixed all the issues.
- Increased TX and RX buffer sizes based on Luc's suggestion (author of ESP3D), not sure if it's needed, but it can't hurt I guess.